### PR TITLE
[Windows] Switch from Windows 8+ futex to std::mutex.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -799,6 +799,7 @@ if env["platform"] == "macos":
     env.Append(CCFLAGS=["-fno-objc-arc", "-fno-objc-msgsend-selector-stubs", "-Wno-unused-command-line-argument"])
 if env["platform"] == "windows":
     env.Append(CPPDEFINES=[("ANGLE_IS_WIN", 1)])
+    env.Append(CPPDEFINES=[("ANGLE_WINDOWS_NO_FUTEX", 1)])
     env.Append(
         CPPDEFINES=[
             (


### PR DESCRIPTION
Restores Windows 7 support.

New Windows 8+ futex implementation was added recently, but seems like it is mostly used by ANGLE over Vulkan backend (which we do not include), it's also disabled in ANGLE builds used by Chromium.