### PR TITLE
Update Angle to chromium/7727

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
           flags: arch=arm64
 
         # MinGW/LLVM libs using UCRT
-        - name: 🏁 Windows - MinGW/LLVM (UCRT) x86_64
+        - name: 🏁 Windows - MinGW/LLVM 21.1.6 (UCRT) x86_64
           platform: windows
           os: windows-2025
           artifact-name: godot-angle-static-x86_64-llvm-release
@@ -71,9 +71,10 @@ jobs:
           artifact-path-egl: bin/libEGL.windows.x86_64.a
           artifact-path-gles: bin/libGLES.windows.x86_64.a
           flags: use_mingw=yes arch=x86_64 use_llvm=yes mingw_prefix=$HOME/llvm-mingw
+          mingw_version: 20251118/llvm-mingw-20251118-ucrt-x86_64
           llvm: yes
 
-        - name: 🏁 Windows - MinGW/LLVM (UCRT) x86_32
+        - name: 🏁 Windows - MinGW/LLVM 21.1.6 (UCRT) x86_32
           platform: windows
           os: windows-2025
           artifact-name: godot-angle-static-x86_32-llvm-release
@@ -81,9 +82,10 @@ jobs:
           artifact-path-egl: bin/libEGL.windows.x86_32.a
           artifact-path-gles: bin/libGLES.windows.x86_32.a
           flags: use_mingw=yes arch=x86_32 use_llvm=yes mingw_prefix=$HOME/llvm-mingw
+          mingw_version: 20251118/llvm-mingw-20251118-ucrt-x86_64
           llvm: yes
 
-        - name: 🏁 Windows - MinGW/LLVM (UCRT) arm64
+        - name: 🏁 Windows - MinGW/LLVM 21.1.6 (UCRT) arm64
           platform: windows
           os: windows-2025
           artifact-name: godot-angle-static-arm64-llvm-release
@@ -91,6 +93,7 @@ jobs:
           artifact-path-egl: bin/libEGL.windows.arm64.a
           artifact-path-gles: bin/libGLES.windows.arm64.a
           flags: use_mingw=yes arch=arm64 use_llvm=yes mingw_prefix=$HOME/llvm-mingw
+          mingw_version: 20251118/llvm-mingw-20251118-ucrt-x86_64
           llvm: yes
 
         # MSVC libs
@@ -121,55 +124,74 @@ jobs:
           artifact-path-gles: bin/libGLES.windows.arm64.lib
           flags: use_mingw=no arch=arm64
 
-        # MinGW/GCC libs using MSVCRT (MinGW 15 / CRT 13)
-        - name: 🏁 Windows - MinGW/GCC (MSVCRT) x86_64
+        # MinGW/GCC libs using UCRT
+        - name: 🏁 Windows - MinGW/GCC 15.2 (UCRT) x86_64
           platform: windows
           os: windows-2025
-          artifact-name: godot-angle-static-x86_64-gcc-13-release
+          artifact-name: godot-angle-static-x86_64-gcc-ucrt-release
           artifact-path-angle: bin/libANGLE.windows.x86_64.a
           artifact-path-egl: bin/libEGL.windows.x86_64.a
           artifact-path-gles: bin/libGLES.windows.x86_64.a
-          flags: use_mingw=yes arch=x86_64 mingw_prefix=C:/mingw64
+          flags: use_mingw=yes arch=x86_64 mingw_prefix=$HOME/gcc-mingw
+          mingw_version: 15.2.0posix-14.0.0-ucrt-r7/winlibs-x86_64-posix-seh-gcc-15.2.0-mingw-w64ucrt-14.0.0-r7
           mingw: yes
-          msys: mingw64
-          msysenv: x86_64
 
-        - name: 🏁 Windows - MinGW/GCC (MSVCRT) x86_32
+        - name: 🏁 Windows - MinGW/GCC 15.2 (UCRT) x86_32
           platform: windows
           os: windows-2025
-          artifact-name: godot-angle-static-x86_32-gcc-13-release
+          artifact-name: godot-angle-static-x86_32-gcc-ucrt-release
           artifact-path-angle: bin/libANGLE.windows.x86_32.a
           artifact-path-egl: bin/libEGL.windows.x86_32.a
           artifact-path-gles: bin/libGLES.windows.x86_32.a
-          flags: use_mingw=yes arch=x86_32 mingw_prefix=C:/mingw32
+          flags: use_mingw=yes arch=x86_32 mingw_prefix=$HOME/gcc-mingw
+          mingw_version: 15.2.0posix-14.0.0-ucrt-r7/winlibs-i686-posix-dwarf-gcc-15.2.0-mingw-w64ucrt-14.0.0-r7
           mingw: yes
-          msys: mingw32
-          msysenv: i686
 
-        # MinGW/GCC libs using MSVCRT (MinGW 14 / CRT 12)
-        - name: 🏁 Windows - MinGW/GCC (MSVCRT) x86_64
+        # MinGW/GCC libs using MSVCRT (MinGW 15 / CRT 14)
+        - name: 🏁 Windows - MinGW/GCC 15.2 (MSVCRT) x86_64
           platform: windows
-          os: windows-2022
+          os: windows-2025
           artifact-name: godot-angle-static-x86_64-gcc-release
           artifact-path-angle: bin/libANGLE.windows.x86_64.a
           artifact-path-egl: bin/libEGL.windows.x86_64.a
           artifact-path-gles: bin/libGLES.windows.x86_64.a
-          flags: use_mingw=yes arch=x86_64 mingw_prefix=C:/mingw64
+          flags: use_mingw=yes arch=x86_64 mingw_prefix=$HOME/gcc-mingw
+          mingw_version: 15.2.0posix-14.0.0-msvcrt-r7/winlibs-x86_64-posix-seh-gcc-15.2.0-mingw-w64msvcrt-14.0.0-r7
           mingw: yes
-          msys: mingw64
-          msysenv: x86_64
 
-        - name: 🏁 Windows - MinGW/GCC (MSVCRT) x86_32
+        - name: 🏁 Windows - MinGW/GCC 15.2 (MSVCRT) x86_32
           platform: windows
-          os: windows-2022
+          os: windows-2025
           artifact-name: godot-angle-static-x86_32-gcc-release
           artifact-path-angle: bin/libANGLE.windows.x86_32.a
           artifact-path-egl: bin/libEGL.windows.x86_32.a
           artifact-path-gles: bin/libGLES.windows.x86_32.a
-          flags: use_mingw=yes arch=x86_32 mingw_prefix=C:/mingw32
+          flags: use_mingw=yes arch=x86_32 mingw_prefix=$HOME/gcc-mingw
+          mingw_version: 15.2.0posix-14.0.0-msvcrt-r7/winlibs-i686-posix-dwarf-gcc-15.2.0-mingw-w64msvcrt-14.0.0-r7
           mingw: yes
-          msys: mingw32
-          msysenv: i686
+
+        # MinGW/GCC libs using MSVCRT (MinGW 14 / CRT 12)
+        - name: 🏁 Windows - MinGW/GCC 14.2 (MSVCRT) x86_64
+          platform: windows
+          os: windows-2025
+          artifact-name: godot-angle-static-x86_64-gcc-crt12-release
+          artifact-path-angle: bin/libANGLE.windows.x86_64.a
+          artifact-path-egl: bin/libEGL.windows.x86_64.a
+          artifact-path-gles: bin/libGLES.windows.x86_64.a
+          flags: use_mingw=yes arch=x86_64 mingw_prefix=$HOME/gcc-mingw
+          mingw_version: 14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64msvcrt-12.0.0-r3
+          mingw: yes
+
+        - name: 🏁 Windows - MinGW/GCC 14.2 (MSVCRT) x86_32
+          platform: windows
+          os: windows-2025
+          artifact-name: godot-angle-static-x86_32-gcc-crt12-release
+          artifact-path-angle: bin/libANGLE.windows.x86_32.a
+          artifact-path-egl: bin/libEGL.windows.x86_32.a
+          artifact-path-gles: bin/libGLES.windows.x86_32.a
+          flags: use_mingw=yes arch=x86_32 mingw_prefix=$HOME/gcc-mingw
+          mingw_version: 14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-i686-posix-dwarf-gcc-14.2.0-mingw-w64msvcrt-12.0.0-r3
+          mingw: yes
   
     runs-on: ${{ matrix.os }}
 
@@ -177,12 +199,12 @@ jobs:
       XCODE_DEV_PATH: "/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'true'
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -201,17 +223,20 @@ jobs:
       - name: Setup MinGW/LLVM
         if: ${{ matrix.platform == 'windows' && matrix.llvm == 'yes' }}
         run: |
-          curl -L -O https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-x86_64.zip
+          curl -L -O https://github.com/mstorsjo/llvm-mingw/releases/download/${{matrix.mingw_version}}.zip
           unzip -q llvm-mingw-*.zip
           rm llvm-mingw-*.zip
           mv llvm-mingw-* "$HOME/llvm-mingw"
           echo "$HOME/llvm-mingw/bin" >> $GITHUB_PATH
 
-      - name: Setup MinGW path
-        if: ${{ matrix.mingw == 'yes' }}
-        shell: bash
+      - name: Setup MinGW/GCC
+        if: ${{ matrix.platform == 'windows' && matrix.mingw == 'yes' }}
         run: |
-          echo "C:/mingw32/bin" >> $GITHUB_PATH
+          curl -L -O https://github.com/brechtsanders/winlibs_mingw/releases/download/${{matrix.mingw_version}}.zip
+          unzip -q winlibs-*.zip
+          rm winlibs-*.zip
+          mv mingw* "$HOME/gcc-mingw"
+          echo "$HOME/gcc-mingw/bin" >> $GITHUB_PATH
 
       - name: Prepare ANGLE source
         shell: bash
@@ -223,7 +248,7 @@ jobs:
           scons platform=${{ matrix.platform }} ${{ matrix.flags }} optimize=speed
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: |
@@ -246,7 +271,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: ZIP Artifacts
         run: |

--- a/SConstruct
+++ b/SConstruct
@@ -156,7 +156,7 @@ print("Building for architecture " + env["arch"] + " on platform " + env["platfo
 
 # Require C++17
 if env.get("is_msvc", False):
-    env.Append(CXXFLAGS=["/std:c++17"])
+    env.Append(CXXFLAGS=["/std:c++20"])
 else:
     env.Append(CXXFLAGS=["-std=c++17"])
 
@@ -276,8 +276,6 @@ angle_sources = [
     "angle/src/compiler/translator/Types.cpp",
     "angle/src/compiler/translator/ValidateAST.cpp",
     "angle/src/compiler/translator/ValidateGlobalInitializer.cpp",
-    "angle/src/compiler/translator/ValidateOutputs.cpp",
-    "angle/src/compiler/translator/ValidateTypeSizeLimitations.cpp",
     "angle/src/compiler/translator/ValidateVaryingLocations.cpp",
     "angle/src/compiler/translator/VariablePacker.cpp",
     "angle/src/compiler/translator/blocklayout.cpp",
@@ -316,7 +314,6 @@ angle_sources = [
     "angle/src/compiler/translator/tree_ops/RemoveInvariantDeclaration.cpp",
     "angle/src/compiler/translator/tree_ops/RemoveUnreferencedVariables.cpp",
     "angle/src/compiler/translator/tree_ops/RemoveUnusedFramebufferFetch.cpp",
-    "angle/src/compiler/translator/tree_ops/RescopeGlobalVariables.cpp",
     "angle/src/compiler/translator/tree_ops/RewriteArrayOfArrayOfOpaqueUniforms.cpp",
     "angle/src/compiler/translator/tree_ops/RewriteAtomicCounters.cpp",
     "angle/src/compiler/translator/tree_ops/RewriteDfdy.cpp",
@@ -475,14 +472,7 @@ if env["platform"] == "macos":
         "angle/src/common/system_utils_apple.cpp",
         "angle/src/common/system_utils_mac.cpp",
         "angle/src/gpu_info_util/SystemInfo_macos.mm",
-        "angle/src/common/gl/cgl/FunctionsCGL.cpp",
         "angle/src/libANGLE/renderer/driver_utils_mac.mm",
-        "angle/src/libANGLE/renderer/gl/cgl/ContextCGL.cpp",
-        "angle/src/libANGLE/renderer/gl/cgl/DeviceCGL.cpp",
-        "angle/src/libANGLE/renderer/gl/cgl/DisplayCGL.mm",
-        "angle/src/libANGLE/renderer/gl/cgl/IOSurfaceSurfaceCGL.cpp",
-        "angle/src/libANGLE/renderer/gl/cgl/PbufferSurfaceCGL.cpp",
-        "angle/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.mm",
     ]
 if env["platform"] == "ios":
     angle_sources += [
@@ -522,6 +512,7 @@ if env["platform"] == "macos" or env["platform"] == "ios":
         "angle/src/compiler/translator/tree_ops/msl/GuardFragDepthWrite.cpp",
         "angle/src/compiler/translator/tree_ops/msl/HoistConstants.cpp",
         "angle/src/compiler/translator/tree_ops/msl/IntroduceVertexIndexID.cpp",
+        "angle/src/compiler/translator/tree_ops/msl/RescopeGlobalVariables.cpp",
         "angle/src/compiler/translator/tree_ops/msl/RewriteCaseDeclarations.cpp",
         "angle/src/compiler/translator/tree_ops/msl/RewriteInterpolants.cpp",
         "angle/src/compiler/translator/tree_ops/msl/RewriteOutArgs.cpp",
@@ -596,7 +587,6 @@ if env["platform"] == "macos" or env["platform"] == "ios":
         "angle/src/libANGLE/renderer/gl/TransformFeedbackGL.cpp",
         "angle/src/libANGLE/renderer/gl/VertexArrayGL.cpp",
         "angle/src/libANGLE/renderer/gl/formatutilsgl.cpp",
-        "angle/src/libANGLE/renderer/gl/null_functions.cpp",
         "angle/src/libANGLE/renderer/gl/renderergl_utils.cpp",
     ]
 if env["platform"] == "windows":
@@ -727,10 +717,6 @@ if env["platform"] == "macos":
     env.Append(CPPDEFINES=["ANGLE_PLATFORM_MACOS"])
     env.Append(CPPDEFINES=[("ANGLE_IS_MAC", 1)])
     env.Append(CPPDEFINES=[("ANGLE_ENABLE_METAL", 1)])
-    env.Append(CPPDEFINES=[("ANGLE_ENABLE_OPENGL", 1)])
-    env.Append(CPPDEFINES=[("ANGLE_ENABLE_GL_DESKTOP_BACKEND", 1)])
-    env.Append(CPPDEFINES=[("ANGLE_ENABLE_GL_NULL", 1)])
-    env.Append(CPPDEFINES=[("ANGLE_ENABLE_CGL", 1)])
     env.Append(CCFLAGS=["-fno-objc-arc", "-fno-objc-msgsend-selector-stubs", "-Wno-unused-command-line-argument"])
 if env["platform"] == "windows":
     env.Append(CPPDEFINES=[("ANGLE_IS_WIN", 1)])
@@ -756,9 +742,6 @@ if env["platform"] == "ios":
     else:
         env.Append(CPPDEFINES=["ANGLE_PLATFORM_IOS_FAMILY_SIMULATOR"])
     env.Append(CPPDEFINES=[("ANGLE_ENABLE_METAL", 1)])
-    env.Append(CPPDEFINES=[("ANGLE_ENABLE_GL_NULL", 1)])
-    env.Append(CPPDEFINES=[("ANGLE_ENABLE_EAGL", 1)])
-    env.Append(CPPDEFINES=[("GLES_SILENCE_DEPRECATION", 1)])
     env.Append(CCFLAGS=["-fno-objc-arc", "-fno-objc-msgsend-selector-stubs", "-Wno-unused-command-line-argument"])
 
 env.Append(CPPDEFINES=[("ANGLE_STANDALONE_BUILD", 1)])

--- a/file_list
+++ b/file_list
@@ -73,8 +73,6 @@
 ./src/compiler/translator/Types.cpp
 ./src/compiler/translator/ValidateAST.cpp
 ./src/compiler/translator/ValidateGlobalInitializer.cpp
-./src/compiler/translator/ValidateOutputs.cpp
-./src/compiler/translator/ValidateTypeSizeLimitations.cpp
 ./src/compiler/translator/ValidateVaryingLocations.cpp
 ./src/compiler/translator/VariablePacker.cpp
 ./src/compiler/translator/blocklayout.cpp
@@ -113,7 +111,6 @@
 ./src/compiler/translator/tree_ops/RemoveInvariantDeclaration.cpp
 ./src/compiler/translator/tree_ops/RemoveUnreferencedVariables.cpp
 ./src/compiler/translator/tree_ops/RemoveUnusedFramebufferFetch.cpp
-./src/compiler/translator/tree_ops/RescopeGlobalVariables.cpp
 ./src/compiler/translator/tree_ops/RewriteArrayOfArrayOfOpaqueUniforms.cpp
 ./src/compiler/translator/tree_ops/RewriteAtomicCounters.cpp
 ./src/compiler/translator/tree_ops/RewriteDfdy.cpp
@@ -251,14 +248,7 @@
 ./src/common/system_utils_apple.cpp
 ./src/common/system_utils_mac.cpp
 ./src/gpu_info_util/SystemInfo_macos.mm
-./src/common/gl/cgl/FunctionsCGL.cpp
 ./src/libANGLE/renderer/driver_utils_mac.mm
-./src/libANGLE/renderer/gl/cgl/ContextCGL.cpp
-./src/libANGLE/renderer/gl/cgl/DeviceCGL.cpp
-./src/libANGLE/renderer/gl/cgl/DisplayCGL.mm
-./src/libANGLE/renderer/gl/cgl/IOSurfaceSurfaceCGL.cpp
-./src/libANGLE/renderer/gl/cgl/PbufferSurfaceCGL.cpp
-./src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.mm
 ./src/common/system_utils_ios.mm
 ./src/gpu_info_util/SystemInfo_ios.cpp
 ./src/libANGLE/renderer/driver_utils_ios.mm
@@ -292,6 +282,7 @@
 ./src/compiler/translator/tree_ops/msl/GuardFragDepthWrite.cpp
 ./src/compiler/translator/tree_ops/msl/HoistConstants.cpp
 ./src/compiler/translator/tree_ops/msl/IntroduceVertexIndexID.cpp
+./src/compiler/translator/tree_ops/msl/RescopeGlobalVariables.cpp
 ./src/compiler/translator/tree_ops/msl/RewriteCaseDeclarations.cpp
 ./src/compiler/translator/tree_ops/msl/RewriteInterpolants.cpp
 ./src/compiler/translator/tree_ops/msl/RewriteOutArgs.cpp
@@ -366,7 +357,6 @@
 ./src/libANGLE/renderer/gl/TransformFeedbackGL.cpp
 ./src/libANGLE/renderer/gl/VertexArrayGL.cpp
 ./src/libANGLE/renderer/gl/formatutilsgl.cpp
-./src/libANGLE/renderer/gl/null_functions.cpp
 ./src/libANGLE/renderer/gl/renderergl_utils.cpp
 ./src/common/system_utils_win.cpp
 ./src/common/system_utils_win32.cpp

--- a/godot-patches/patch_mingw_build.diff
+++ b/godot-patches/patch_mingw_build.diff
@@ -2,7 +2,8 @@ diff --git a/angle/include/platform/PlatformMethods.h b/angle/include/platform/P
 index a3233a2cd5..b4e684842c 100644
 --- a/angle/include/platform/PlatformMethods.h
 +++ b/angle/include/platform/PlatformMethods.h
-@@ -313,7 +313,7 @@ extern "C" {
+@@ -312,17 +312,17 @@ extern "C" {
+ // match the compiled signature for this ANGLE, false is returned. On success true is returned.
  // The application should set any platform methods it cares about on the returned pointer.
  // If display is not valid, behaviour is undefined.
  
@@ -11,7 +12,7 @@ index a3233a2cd5..b4e684842c 100644
                                                                    const char *const methodNames[],
                                                                    unsigned int methodNameCount,
                                                                    void *context,
-@@ -321,7 +321,7 @@ ANGLE_PLATFORM_EXPORT bool ANGLE_APIENTRY ANGLEGetDisplayPlatform(angle::EGLDisp
+                                                                   void *platformMethodsOut);
  
  // Sets the platform methods back to their defaults.
  // If display is not valid, behaviour is undefined.
@@ -20,11 +21,24 @@ index a3233a2cd5..b4e684842c 100644
  }  // extern "C"
  
  namespace angle
+ {
 diff --git a/angle/src/libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.cpp b/angle/src/libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.cpp
-index 0e64f78d53..17ed63e66c 100644
+index df34085649..bcb178518d 100644
 --- a/angle/src/libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.cpp
 +++ b/angle/src/libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.cpp
-@@ -38,14 +38,22 @@ bool CompositorNativeWindow11::getClientRect(LPRECT rect) const
+@@ -6,8 +6,10 @@
+ 
+ // CompositorNativeWindow11.cpp: Implementation of NativeWindow11 using Windows.UI.Composition APIs
+ // which work in both Win32 and WinRT contexts.
+ 
++#define ____FIReference_1_boolean_INTERFACE_DEFINED__
++
+ #include "libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.h"
+ #include "libANGLE/renderer/d3d/d3d11/renderer11_utils.h"
+ 
+ #include "common/debug.h"
+@@ -37,16 +39,24 @@ bool CompositorNativeWindow11::getClientRect(LPRECT rect) const
+     ComPtr<ABI::Windows::UI::Composition::IVisual> visual;
      mHostVisual.As(&visual);
  
      ABI::Windows::Foundation::Numerics::Vector2 size;
@@ -47,11 +61,13 @@ index 0e64f78d53..17ed63e66c 100644
      if (FAILED(hr))
      {
          return false;
+     }
 diff --git a/angle/src/libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.h b/angle/src/libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.h
-index 688f937724..8f3232cc72 100644
+index 688f937724..7c1d6189d2 100644
 --- a/angle/src/libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.h
 +++ b/angle/src/libANGLE/renderer/d3d/d3d11/converged/CompositorNativeWindow11.h
-@@ -12,6 +12,147 @@
+@@ -11,8 +11,149 @@
+ #define LIBANGLE_RENDERER_D3D_D3D11_CONVERGED_COMPOSITORNATIVEWINDOW11_H_
  
  #include "libANGLE/renderer/d3d/d3d11/NativeWindow11.h"
  
@@ -199,3 +215,19 @@ index 688f937724..8f3232cc72 100644
  #include <DispatcherQueue.h>
  #include <windows.foundation.metadata.h>
  #include <windows.ui.composition.h>
+ #include <windows.ui.composition.interop.h>
+diff --git a/angle/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp b/angle/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
+index a24fbc52f7..3f406c5a0e 100644
+--- a/angle/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
++++ b/angle/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
+@@ -5,8 +5,10 @@
+ //
+ 
+ // Renderer11.cpp: Implements a back-end specific class for the D3D11 renderer.
+ 
++#define ____FIReference_1_boolean_INTERFACE_DEFINED__
++
+ #ifdef UNSAFE_BUFFERS_BUILD
+ #    pragma allow_unsafe_buffers
+ #endif
+ 


### PR DESCRIPTION
Updates Angle to [current Chrome stable version](https://chromium.googlesource.com/angle/angle/+/refs/heads/chromium/7727).

Fixes build with a newer MinGW versions (fixes https://github.com/godotengine/godot-angle-static/issues/15)
Disables unused desktop GL backend on macOS.

TODO:

- [x] Test for regressions on MacOS
- [x] Test for regressions on Windows

*Edit:* It seems to be working fine, but since it's not fixing any specific issues, probably should wait for 4.8.

| File | Toolchain |
|--|--|
| godot-angle-static-arm64-macos-release | Xcode 26.1.1 |
| godot-angle-static-x86_64-macos-release | Xcode 26.1.1 |
| godot-angle-static-arm64-ios-release | Xcode 26.1.1 |
| godot-angle-static-arm64-ios-sim-release | Xcode 26.1.1 |
| godot-angle-static-x86_64-ios-sim-release | Xcode 26.1.1 |
| godot-angle-static-arm64-llvm-release | LLVM 21.1.6, UCRT, MinGW 14.0.0 |
| godot-angle-static-x86_64-llvm-release | LLVM 21.1.6, UCRT, MinGW 14.0.0 |
| godot-angle-static-x86_32-llvm-release | LLVM 21.1.6, UCRT, MinGW 14.0.0 |
| godot-angle-static-arm64-msvc-release | MSVC 2022 17.14.37314.3| 
| godot-angle-static-x86_64-msvc-release | MSVC 2022 17.14.37314.3|
| godot-angle-static-x86_32-msvc-release | MSVC 2022 17.14.37314.3| 
| godot-angle-static-x86_64-gcc-release | GCC 15.2.0, MSVCRT, Posix threads, MinGW 14.0.0 |
| godot-angle-static-x86_32-gcc-release | GCC 15.2.0, MSVCRT, Posix threads, MinGW 14.0.0 |
| godot-angle-static-x86_64-gcc-ucrt-release | GCC 15.2.0, UCRT, Posix threads, MinGW 14.0.0 |
| godot-angle-static-x86_32-gcc-ucrt-release | GCC 15.2.0, UCRT, Posix threads, MinGW 14.0.0 |
| godot-angle-static-x86_64-gcc-crt12-release | GCC 14.2.0, MSVCRT, Posix threads, MinGW 12.0.0 |
| godot-angle-static-x86_32-gcc-crt12-release | GCC 14.2.0, MSVCRT, Posix threads, MinGW 12.0.0 |
